### PR TITLE
Ximing: Modified GetTaskUseCase

### DIFF
--- a/src/api/TodoistDB.java
+++ b/src/api/TodoistDB.java
@@ -168,7 +168,7 @@ public class TodoistDB implements AddProjectDataAccessInterface, GetTaskDataAcce
     }
 
     //Precondition: the project name provided exists
-    public Pair<String, ArrayList<Task>> getTasks(String name) {
+    public Pair<String, ArrayList<ArrayList<String>>> getTasks(String name) {
         this.getProject();
         String id = all_projects.get(name);
         OkHttpClient client = new OkHttpClient().newBuilder()
@@ -182,9 +182,13 @@ public class TodoistDB implements AddProjectDataAccessInterface, GetTaskDataAcce
             Response response = client.newCall(request).execute();
             JSONArray responseBody = new JSONArray(response.body().string());
             if (response.code() == 200) {
-                ArrayList<Task> tasks = new ArrayList<>();
+//                ArrayList<Task> tasks = new ArrayList<>();
+                ArrayList<String> taskName = new ArrayList<>();
+                ArrayList<String> taskId = new ArrayList<>();
+                ArrayList<String> taskDeadline = new ArrayList<>();
                 for (int i = 0; i < responseBody.length(); i++) {
                     JSONObject element = responseBody.getJSONObject(i);
+
                     if (element.getString("project_id").equals(id)) {
 
                         String deadline = "";
@@ -192,17 +196,25 @@ public class TodoistDB implements AddProjectDataAccessInterface, GetTaskDataAcce
                             JSONObject dueObject = element.getJSONObject("due");
                             deadline = dueObject.getString("string");
                         }
+                        taskName.add(element.getString("content"));
+                        taskId.add(element.getString("id"));
+                        taskDeadline.add(deadline);
+//                        Task task = Task.builder()
+//                                .TaskId(element.getString("id"))
+//                                .TaskName(element.getString("content"))
+//                                .ProjectId(element.getString("project_id"))
+//                                .Deadline(deadline)
+//                                .build();
+//                        tasks.add(task);
 
-                        Task task = Task.builder()
-                                .TaskId(element.getString("id"))
-                                .TaskName(element.getString("content"))
-                                .ProjectId(element.getString("project_id"))
-                                .Deadline(deadline)
-                                .build();
-                        tasks.add(task);
                     }
                 }
-                Pair<String, ArrayList<Task>> result = new Pair<>(name, tasks);
+                ArrayList<ArrayList<String>> task = new ArrayList<>();
+                task.add(taskName);
+                task.add(taskId);
+                task.add(taskDeadline);
+//                Pair<String, ArrayList<Task>> result = new Pair<>(name, tasks);
+                Pair<String, ArrayList<ArrayList<String>>> result = new Pair<>(name, task);
                 return result;
             } else {
                 throw new RuntimeException("Error");

--- a/src/interface_adapter/get_task/GetTaskPresenter.java
+++ b/src/interface_adapter/get_task/GetTaskPresenter.java
@@ -19,7 +19,10 @@ public class GetTaskPresenter implements GetTaskOutputBoundary {
         // On success, switch to task view
         String projectName = response.getProjectName();
         GetTaskState getTaskState = getTaskViewModel.getState();
-        getTaskState.setTasks(response.getTasks());
+//        getTaskState.setTasks(response.getTasks());
+        getTaskState.setTaskId(response.getTaskId());
+        getTaskState.setTaskName(response.getTaskName());
+        getTaskState.setTaskDeadline(response.getTaskDeadline());
         getTaskState.setMessage(response.getMessage());
         getTaskViewModel.setState(getTaskState);
         getTaskViewModel.firePropertyChanged();

--- a/src/interface_adapter/get_task/GetTaskState.java
+++ b/src/interface_adapter/get_task/GetTaskState.java
@@ -1,21 +1,46 @@
 package interface_adapter.get_task;
 
-import entity.Task;
-
 import java.util.ArrayList;
 
 public class GetTaskState {
-    private ArrayList<Task> tasks;
+//    private ArrayList<Task> tasks;
+    ArrayList<String> taskName;
+    ArrayList<String> taskId;
+    ArrayList<String> taskDeadline;
     private String message;
 
     public GetTaskState() {}
 
-    public ArrayList<Task> getTasks() {
-        return tasks;
+//    public ArrayList<Task> getTasks() {
+//        return tasks;
+//    }
+//
+//    public void setTasks(ArrayList<Task> tasks) {
+//        this.tasks = tasks;
+//    }
+
+    public ArrayList<String> getTaskName() {
+        return taskName;
     }
 
-    public void setTasks(ArrayList<Task> tasks) {
-        this.tasks = tasks;
+    public void setTaskName(ArrayList<String> taskName) {
+        this.taskName = taskName;
+    }
+
+    public ArrayList<String> getTaskId() {
+        return taskId;
+    }
+
+    public void setTaskId(ArrayList<String> taskId) {
+        this.taskId = taskId;
+    }
+
+    public ArrayList<String> getTaskDeadline() {
+        return taskDeadline;
+    }
+
+    public void setTaskDeadline(ArrayList<String> taskDeadline) {
+        this.taskDeadline = taskDeadline;
     }
 
     public String getMessage() {return message;}

--- a/src/use_case/get_task/GetTaskDataAccessInterface.java
+++ b/src/use_case/get_task/GetTaskDataAccessInterface.java
@@ -8,6 +8,6 @@ import java.util.ArrayList;
 
 public interface GetTaskDataAccessInterface {
     boolean existsByName(String name);
-    Pair<String, ArrayList<Task>> getTasks(String name);
+    Pair<String, ArrayList<ArrayList<String>>> getTasks(String name);
     public String getMessage();
 }

--- a/src/use_case/get_task/GetTaskInteractor.java
+++ b/src/use_case/get_task/GetTaskInteractor.java
@@ -22,7 +22,7 @@ public class GetTaskInteractor implements GetTaskInputBoundary{
 //            presenter.prepareFailView("Project does not exist.");
 //        } else {
             String name = getTaskInputData.getName();
-            Pair<String, ArrayList<Task>> result = dataAccessObject.getTasks(name);
+            Pair<String, ArrayList<ArrayList<String>>> result = dataAccessObject.getTasks(name);
             String message = dataAccessObject.getMessage();
             GetTaskOutputData getTaskOutputData = new GetTaskOutputData(result, message);
             presenter.prepareSuccessView(getTaskOutputData);

--- a/src/use_case/get_task/GetTaskOutputData.java
+++ b/src/use_case/get_task/GetTaskOutputData.java
@@ -6,23 +6,44 @@ import kotlin.Pair;
 import java.util.ArrayList;
 
 public class GetTaskOutputData {
-    private final ArrayList<Task> tasks;
+    private final ArrayList<String> taskName;
+    private final ArrayList<String> taskId;
+    private final ArrayList<String> taskDeadline;
+
+//    private final ArrayList<Task> tasks;
     private final String projectName;
     private final String message;
 
-    public GetTaskOutputData(Pair<String, ArrayList<Task>> result, String message) {
+    //ArrayList<ArrayList<String>>> <Taskname, TaskId, TaskDeadline>
+    public GetTaskOutputData(Pair<String, ArrayList<ArrayList<String>>> result, String message) {
+        this.taskName = result.getSecond().get(0);
+        this.taskId = result.getSecond().get(1);
+        this.taskDeadline = result.getSecond().get(2);
         this.projectName= result.getFirst();
-        this.tasks = result.getSecond();
+//        this.tasks = result.getSecond();
         this.message = message;
     }
 
-    public ArrayList<Task> getTasks() {
-        return tasks;
-    }
+//    public ArrayList<Task> getTasks() {
+//        return tasks;
+//    }
+
 
     public String getProjectName() {
         return projectName;
     }
 
     public String getMessage() {return message;}
+
+    public ArrayList<String> getTaskName() {
+        return taskName;
+    }
+
+    public ArrayList<String> getTaskId() {
+        return taskId;
+    }
+
+    public ArrayList<String> getTaskDeadline() {
+        return taskDeadline;
+    }
 }

--- a/src/view/GetTaskView.java
+++ b/src/view/GetTaskView.java
@@ -154,20 +154,35 @@ public class GetTaskView extends JPanel implements ActionListener, PropertyChang
         if (state instanceof GetTaskState) {
             GetTaskState getTaskState = (GetTaskState) state;
 
-            java.util.List<Task> tasks = new ArrayList<>(getTaskState.getTasks());
+//            java.util.List<Task> tasks = new ArrayList<>(getTaskState.getTasks());
+//
+//            tasksArea.removeAll();
+//            for (Task task : tasks) {
+//
+//                String deadlineText = task.getDeadline() != null && !task.getDeadline().isEmpty()
+//                        ? " (Deadline: " + task.getDeadline() + ")"
+//                        : ""; // If there is no deadline, it is not displayed
+//                String taskText = task.getTaskName() + deadlineText;
+//                JCheckBox checkBox = new JCheckBox(taskText);
+//
+//                checkBox.addActionListener(e -> handleCheckBoxAction(task.getTaskId(), checkBox));
+//                tasksArea.add(checkBox);
+//            }
 
+            ArrayList<String> taskName = getTaskState.getTaskName();
+            ArrayList<String> taskId = getTaskState.getTaskId();
+            ArrayList<String> taskDeadline = getTaskState.getTaskDeadline();
             tasksArea.removeAll();
-            for (Task task : tasks) {
-
-                String deadlineText = task.getDeadline() != null && !task.getDeadline().isEmpty()
-                        ? " (Deadline: " + task.getDeadline() + ")"
+            for (int s = 0; s != taskName.size(); s ++) {
+                String deadlineText = taskDeadline.get(s) != null && !taskDeadline.get(s).isEmpty()
+                        ? " (Deadline: " + taskDeadline.get(s) + ")"
                         : ""; // If there is no deadline, it is not displayed
-                String taskText = task.getTaskName() + deadlineText;
+                String taskText = taskName.get(s) + deadlineText;
                 JCheckBox checkBox = new JCheckBox(taskText);
-
-                checkBox.addActionListener(e -> handleCheckBoxAction(task.getTaskId(), checkBox));
+                int finalS = s;
+                checkBox.addActionListener(e -> handleCheckBoxAction(taskId.get(finalS), checkBox));
                 tasksArea.add(checkBox);
-            }
+            };
 
             message.setText(getTaskState.getMessage());
             message.setFont(new Font("Serif", Font.ITALIC, 15));


### PR DESCRIPTION
The original GetTaskUseCase didn't comply with the clean architecture diagram. The GetTaskOutputData class was dependent on the Task entity class. I resolved this issue by changing the type of the corresponding instance variable in the OutputData.